### PR TITLE
Changed webpack dev server port number to 3000

### DIFF
--- a/music-client/package.json
+++ b/music-client/package.json
@@ -6,7 +6,7 @@
   "license": "APACHE2",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot --port 3000",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {


### PR DESCRIPTION
The Vue CLI webpack-simple template doesn't have a dedicated webpack-dev-server config file (which is normally where you'd set the port number for the dev server). However we can also set the port number using the `--port` flag in the `dev` script line, in `package.json`. That's what I've done here. 

Otherwise the default behavior is to start on port 8080, jumping up ports if one is not available.