### PR TITLE
import Bootstrap CSS (and handle fonts correctly)

### DIFF
--- a/music-client/index.html
+++ b/music-client/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>music-client</title>
-    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
   </head>
   <body>
     <div id="app"></div>

--- a/music-client/src/main.js
+++ b/music-client/src/main.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import App from './App.vue'
 import VueResource from 'vue-resource'
+import 'bootstrap/dist/css/bootstrap.css'
 
 Vue.use(VueResource);
 

--- a/music-client/webpack.config.js
+++ b/music-client/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
         exclude: /node_modules/
       },
       {
-        test: /\.(png|jpg|gif|svg)$/,
+        test: /\.(png|jpg|gif|svg|ttf|eot|woff|woff2)$/,
         loader: 'file-loader',
         options: {
           name: '[name].[ext]?[hash]'


### PR DESCRIPTION
Rather than using a HTML tag to bring in the CSS from `node_modules`, it's better to import them into the component/s that actually need them, using `import`. This will resolve assets from `node_modules` correctly and make sure things are pulled in when you expect. I also had to change the Webpack config to correctly handle the font files that Bootstrap now includes. 