### PR TITLE
Server url

### DIFF
--- a/music-client/src/config.js
+++ b/music-client/src/config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  DEV_SERVER_URL: '"http://localhost:8080"',
-  PROD_SERVER_URL: '""' //server root
+  DEV_SERVER_URL: 'http://localhost:8080',
+  PROD_SERVER_URL: '' //server root
 }

--- a/music-client/src/config.js
+++ b/music-client/src/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  DEV_SERVER_URL: '"http://localhost:8080"',
+  PROD_SERVER_URL: '""' //server root
+}

--- a/music-client/src/main.js
+++ b/music-client/src/main.js
@@ -1,11 +1,14 @@
 import Vue from 'vue'
 import App from './App.vue'
 import VueResource from 'vue-resource'
+import {DEV_SERVER_URL, PROD_SERVER_URL} from './config'
 
 Vue.use(VueResource);
 
 if (process.env.NODE_ENV !== 'production') {
-  Vue.http.options.root = 'http://localhost:8080'
+  Vue.http.options.root = DEV_SERVER_URL
+} else {
+  Vue.http.options.root = PROD_SERVER_URL
 }
 new Vue({
   el: '#app',


### PR DESCRIPTION
The existing approach is reasonable, considering this is a simple project and the `webpack-simple` template does not have environment specific config files  (which the more full-featured `webpack` template provides). I moved the URL string into a single `config` file, and included a version for dev and prod modes, just to make a cleaner separation between the config and the app code. This is optional, the existing code should work fine.