### PR TITLE
Replaced HttpParameters with QueryValue

### DIFF
--- a/music-service/src/main/java/music/service/MusicController.java
+++ b/music-service/src/main/java/music/service/MusicController.java
@@ -1,9 +1,9 @@
 package music.service;
 
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.HttpParameters;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
 import music.service.search.ItunesClient;
 import music.service.search.SearchResult;
 
@@ -19,8 +19,7 @@ public class MusicController {
     }
 
     @Get("/search/{searchTerm}")
-    public List<Album> search(String searchTerm, HttpParameters parameters) {
-        String maxResults = parameters.get("maxResults");
+    public List<Album> search(String searchTerm, @QueryValue String maxResults) {
         final int limit;
         if(StringUtils.isDigits(maxResults)) {
             limit = Math.min(25, Integer.parseInt(maxResults));


### PR DESCRIPTION
The `@QueryValue` annotation will bind an HTTP parameter to a named argument, without needing to access the HttpParameters directly. See: https://docs.micronaut.io/snapshot/api/io/micronaut/http/annotation/QueryValue.html